### PR TITLE
[Fix] Gender field displaying label below it

### DIFF
--- a/src/components/user/signupForm/SignUpForm.js
+++ b/src/components/user/signupForm/SignUpForm.js
@@ -73,7 +73,6 @@ export const SignUpForm = ({ onSubmit }) => {
     handleValueChange,
     handleFocus,
     handleBlur,
-    values,
     errors,
     activeFields,
     touched


### PR DESCRIPTION
## Links (Jira/Trello ticket and other relevant links):
https://trello.com/c/nPFo5pBP/22-bug-fix-label-poping-up-in-sign-up-page

## What & Why:
Gender field displaying label below it

## Notes:
Custom hook was expecting less arguments and was receiving values as errors thus always displaying an error 
